### PR TITLE
Fix plot detections and reprojections function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,19 +52,23 @@ jobs:
           which python
           conda info
           conda list
+          
       - name: Test with pytest
         if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.8) }}
         shell: bash -l {0}
         run: |
           pytest
+
       - name: Test with pytest (with coverage)
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.8 }}
         shell: bash -l {0}
         run: |
           pytest --cov=sleap_anipose --cov-report=xml tests/
+
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.8 }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: false

--- a/sleap_anipose/__init__.py
+++ b/sleap_anipose/__init__.py
@@ -1,4 +1,5 @@
 """High-level imports."""
+
 from sleap_anipose.calibration import calibrate, draw_board
 from sleap_anipose.triangulation import load_view, load_tracks, triangulate, reproject
 

--- a/sleap_anipose/calibration.py
+++ b/sleap_anipose/calibration.py
@@ -64,13 +64,13 @@ def make_histogram(
         plt.savefig(save_path, format="png", dpi="figure")
 
 def make_reproj_imgs(
-        detections: np.ndarray,
-        reprojections: np.ndarray,
-        frames: List[int],
-        session: str,
-        excluded_views: Tuple[str] = (),
-        n_samples=4,
-        save_path: str = "",
+    detections: np.ndarray,
+    reprojections: np.ndarray,
+    frames: List[int],
+    session: str,
+    excluded_views: Tuple[str] = (),
+    n_samples=4,
+    save_path: str = "",
 ):
     """Make visualization of calibrated board corners.
 

--- a/sleap_anipose/calibration.py
+++ b/sleap_anipose/calibration.py
@@ -63,15 +63,14 @@ def make_histogram(
     if save:
         plt.savefig(save_path, format="png", dpi="figure")
 
-
 def make_reproj_imgs(
-    detections: np.ndarray,
-    reprojections: np.ndarray,
-    frames: List[int],
-    session: str,
-    excluded_views: Tuple[str] = (),
-    n_samples=4,
-    save_path: str = "",
+        detections: np.ndarray,
+        reprojections: np.ndarray,
+        frames: List[int],
+        session: str,
+        excluded_views: Tuple[str] = (),
+        n_samples=4,
+        save_path: str = "",
 ):
     """Make visualization of calibrated board corners.
 
@@ -92,6 +91,7 @@ def make_reproj_imgs(
             string, images will not be saved. Images are saved to the view subfolders in
             this folder as 'save_path / view / reprojection-{frame}.png'.
     """
+
     cam_folders = sorted(
         [
             x
@@ -101,31 +101,16 @@ def make_reproj_imgs(
     )
     sampled_frames = sample(frames, n_samples)
 
-    ## Test to see if the sampled frames are in the frames list
-    assert all(
-        frame in frames for frame in sampled_frames
-    ), "Sampled frames are not in the original frames list."
-
-    print(f"FRAMES: {frames}")
-    print(f"SAMPLED FRAMES: {sampled_frames}")
-    print(f"cam_folders: {cam_folders}")
-
     for i, cam in enumerate(cam_folders):
-        print(f"cam: {cam}")
+        # grab file name 
+        image_path = list(cam.glob(f"*calibration_images/*.mp4"))
+
+        # open mp4 
+        vid = imageio.get_reader(image_path[0],  'ffmpeg')
+
         for frame in sampled_frames:
-            image_path = list(cam.glob(f"*/*{frame}.jpg"))
-            print(f"image_path: {image_path}")
-            img = imageio.imread(image_path[0]) # looks for image with frame number
+            img = vid.get_data(frame)
 
-            print(f"detection shape: {detections.shape}")
-            print(f"reprojection shape: {reprojections.shape}")
-            #print(f"frames[frame] = {frames[frame]}")
-            print(f"frame = {frame}")
-            print(f"frames.index(frame) = {frames.index(frame)}")
-
-            assert detections.shape == reprojections.shape, "Detections and reprojections must have the same shape."
-            #assert frames[frame] == frames.index(frame) #this breaks things
-            
             fig = plt.figure(figsize=(14, 12), dpi=120, facecolor="w")
             plt.scatter(
                 detections[i, frames.index(frame), :, 0], ## could it be frames[frame] vs frames.index(frame)
@@ -156,7 +141,7 @@ def make_reproj_imgs(
                 fname = cam / f"reprojection-{frame}.png"
                 print(f"fname = {fname}")
                 plt.savefig(fname, format="png", dpi="figure")
-
+                plt.close()
 
 def get_metadata(
     corner_data: List[List[Dict]], cgroup: CameraGroup, save_path: str = ""

--- a/sleap_anipose/calibration.py
+++ b/sleap_anipose/calibration.py
@@ -102,18 +102,15 @@ def make_reproj_imgs(
     sampled_frames = sample(frames, n_samples)
 
     for i, cam in enumerate(cam_folders):
-        # grab file name 
         image_path = list(cam.glob(f"*calibration_images/*.mp4"))
-
-        # open mp4 
         vid = imageio.get_reader(image_path[0],  'ffmpeg')
 
         for frame in sampled_frames:
             img = vid.get_data(frame)
-
+            
             fig = plt.figure(figsize=(14, 12), dpi=120, facecolor="w")
             plt.scatter(
-                detections[i, frames.index(frame), :, 0], ## could it be frames[frame] vs frames.index(frame)
+                detections[i, frames.index(frame), :, 0], 
                 detections[i, frames.index(frame), :, 1],
                 s=300,
                 color="r",

--- a/sleap_anipose/calibration.py
+++ b/sleap_anipose/calibration.py
@@ -63,6 +63,7 @@ def make_histogram(
     if save:
         plt.savefig(save_path, format="png", dpi="figure")
 
+
 def make_reproj_imgs(
     detections: np.ndarray,
     reprojections: np.ndarray,
@@ -103,14 +104,14 @@ def make_reproj_imgs(
 
     for i, cam in enumerate(cam_folders):
         image_path = list(cam.glob(f"*calibration_images/*.mp4"))
-        vid = imageio.get_reader(image_path[0],  'ffmpeg')
+        vid = imageio.get_reader(image_path[0], "ffmpeg")
 
         for frame in sampled_frames:
             img = vid.get_data(frame)
 
             fig = plt.figure(figsize=(14, 12), dpi=120, facecolor="w")
             plt.scatter(
-                detections[i, frames.index(frame), :, 0], 
+                detections[i, frames.index(frame), :, 0],
                 detections[i, frames.index(frame), :, 1],
                 s=300,
                 color="r",
@@ -134,10 +135,13 @@ def make_reproj_imgs(
 
             print(f"Save path = {save_path}")
 
-            if len(save_path) > 0:
-                fname = cam / f"reprojection-{frame}.png"
-                plt.savefig(fname, format="png", dpi="figure")
-                plt.close()
+            if len(str(save_path)) > 0:  # Convert to string
+                output_dir = Path(save_path) / cam.name
+                output_dir.mkdir(parents=True, exist_ok=True)
+                output_file = output_dir / f"reprojection-{frame}.png"
+                fig.savefig(output_file.as_posix(), bbox_inches="tight")
+                plt.close(fig)
+
 
 def get_metadata(
     corner_data: List[List[Dict]], cgroup: CameraGroup, save_path: str = ""

--- a/sleap_anipose/calibration.py
+++ b/sleap_anipose/calibration.py
@@ -107,7 +107,7 @@ def make_reproj_imgs(
 
         for frame in sampled_frames:
             img = vid.get_data(frame)
-            
+
             fig = plt.figure(figsize=(14, 12), dpi=120, facecolor="w")
             plt.scatter(
                 detections[i, frames.index(frame), :, 0], 
@@ -136,7 +136,6 @@ def make_reproj_imgs(
 
             if len(save_path) > 0:
                 fname = cam / f"reprojection-{frame}.png"
-                print(f"fname = {fname}")
                 plt.savefig(fname, format="png", dpi="figure")
                 plt.close()
 

--- a/sleap_anipose/calibration.py
+++ b/sleap_anipose/calibration.py
@@ -101,12 +101,34 @@ def make_reproj_imgs(
     )
     sampled_frames = sample(frames, n_samples)
 
+    ## Test to see if the sampled frames are in the frames list
+    assert all(
+        frame in frames for frame in sampled_frames
+    ), "Sampled frames are not in the original frames list."
+
+    print(f"FRAMES: {frames}")
+    print(f"SAMPLED FRAMES: {sampled_frames}")
+    print(f"cam_folders: {cam_folders}")
+
     for i, cam in enumerate(cam_folders):
+        print(f"cam: {cam}")
         for frame in sampled_frames:
-            img = imageio.imread(list(cam.glob(f"*/*{frame}.jpg"))[0])
+            image_path = list(cam.glob(f"*/*{frame}.jpg"))
+            print(f"image_path: {image_path}")
+            img = imageio.imread(image_path[0]) # looks for image with frame number
+
+            print(f"detection shape: {detections.shape}")
+            print(f"reprojection shape: {reprojections.shape}")
+            #print(f"frames[frame] = {frames[frame]}")
+            print(f"frame = {frame}")
+            print(f"frames.index(frame) = {frames.index(frame)}")
+
+            assert detections.shape == reprojections.shape, "Detections and reprojections must have the same shape."
+            #assert frames[frame] == frames.index(frame) #this breaks things
+            
             fig = plt.figure(figsize=(14, 12), dpi=120, facecolor="w")
             plt.scatter(
-                detections[i, frames.index(frame), :, 0],
+                detections[i, frames.index(frame), :, 0], ## could it be frames[frame] vs frames.index(frame)
                 detections[i, frames.index(frame), :, 1],
                 s=300,
                 color="r",
@@ -128,8 +150,11 @@ def make_reproj_imgs(
             plt.yticks([])
             plt.legend()
 
+            print(f"Save path = {save_path}")
+
             if len(save_path) > 0:
                 fname = cam / f"reprojection-{frame}.png"
+                print(f"fname = {fname}")
                 plt.savefig(fname, format="png", dpi="figure")
 
 

--- a/sleap_anipose/calibration.py
+++ b/sleap_anipose/calibration.py
@@ -92,7 +92,6 @@ def make_reproj_imgs(
             string, images will not be saved. Images are saved to the view subfolders in
             this folder as 'save_path / view / reprojection-{frame}.png'.
     """
-
     cam_folders = sorted(
         [
             x


### PR DESCRIPTION
The problem in Issue #41 was caused by a mismatch between the number of frames in the video and the length of the frames list input into the make_reproj_imgs() function. In my tests, I noticed that earlier sample frames seemed to match, while later sampled frames did not match. This is because each of the frames that lead to no detections would be subtracted from the list of total frames. So they become progressively more mismatched. The good news however is that the calibration itself was not compromised by this bug just the plotting. So calibration files should be good to go, and histograms remain an accurate representation of the error.

I have written a new version of the make_reproj_imgs() function which grabs the frame from the video using imageio and ffmpeg rather than from a list of images. The eric/calibration-imgs branch eliminates the problem of misaligned detections, reprojections and images described in Issue #41. 