### PR TITLE
add slap-reproject to setup cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ console_scripts =
     slap-triangulate = sleap_anipose:triangulation.triangulate_cli
     slap-write_board = sleap_anipose:calibration.write_board_cli
     slap-draw_board = sleap_anipose:calibration.draw_board_cli
+    slap-reproject = sleap_anipose.triangulation:reproject_cli
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ console_scripts =
     slap-triangulate = sleap_anipose:triangulation.triangulate_cli
     slap-write_board = sleap_anipose:calibration.write_board_cli
     slap-draw_board = sleap_anipose:calibration.draw_board_cli
-    slap-reproject = sleap_anipose.triangulation:reproject_cli
+    slap-reproject = sleap_anipose:triangulation:reproject_cli
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ console_scripts =
     slap-triangulate = sleap_anipose:triangulation.triangulate_cli
     slap-write_board = sleap_anipose:calibration.write_board_cli
     slap-draw_board = sleap_anipose:calibration.draw_board_cli
-    slap-reproject = sleap_anipose:triangulation:reproject_cli
+    slap-reproject = sleap_anipose:triangulation.reproject_cli
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Running 'slap-reproject' resulted in an error where 'slap-reproject is not recognized as an internal or external command' which was identified in issue #46.  This was because the reproject_cli was not added to the setup.cfg file in the console_scripts entry points. I have added slap-reproject to that list and the file is now being created as expected. 